### PR TITLE
[Feat/#24] 인터벌 삭제, 리프레쉬, 업데이트 구현

### DIFF
--- a/Projects/App/WatchExtension/Sources/DIContainer/IntervalDIContainer.swift
+++ b/Projects/App/WatchExtension/Sources/DIContainer/IntervalDIContainer.swift
@@ -12,6 +12,7 @@ import Domain
 import Data
 
 public final class IntervalDIContainer: IntervalDIContainerInterface {
+    
     public func intervalRouter() -> IntervalRouter {
         return IntervalRouter(intervalDIContainer: self)
     }
@@ -27,7 +28,7 @@ public final class IntervalDIContainer: IntervalDIContainerInterface {
         )
     }
     
-    public func intervalActiveDependencies(intervalRouter: IntervalRouter) -> IntervalActiveViewModel {
+    public func intervalActiveDependencies(intervalRouter: IntervalRouter) -> IntervalActiveViewModelWithRouter {
         let intervalDataSource = IntervalDataSource()
         let intervalRepository = IntervalRepository(dataSource: intervalDataSource)
         let intervalUseCase = IntervalUseCase(intervalRepository: intervalRepository)
@@ -38,7 +39,7 @@ public final class IntervalDIContainer: IntervalDIContainerInterface {
         )
     }
     
-    public func intervalListDependencies(intervalRouter: IntervalRouter) -> IntervalListViewModel {
+    public func intervalListDependencies(intervalRouter: IntervalRouter) -> IntervalListViewModelWithRouter {
         let intervalDataSource = IntervalDataSource()
         let intervalRepository = IntervalRepository(dataSource: intervalDataSource)
         let intervalUseCase = IntervalUseCase(intervalRepository: intervalRepository)
@@ -49,16 +50,28 @@ public final class IntervalDIContainer: IntervalDIContainerInterface {
         )
     }
     
-    public func addIntervalDependencies(intervalRouter: IntervalRouter) -> AddIntervalViewModel {
+    public func addIntervalDependencies(intervalRouter: IntervalRouter) -> AddIntervalViewModelWithRouter {
         let intervalDataSource = IntervalDataSource()
         let intervalRepository = IntervalRepository(dataSource: intervalDataSource)
         let intervalUseCase = IntervalUseCase(intervalRepository: intervalRepository)
-        
+    
         return AddIntervalViewModelWithRouter(router: intervalRouter, intervalUseCase: intervalUseCase)
 
     }
     
-    public func intervalDetailDependencies(intervalRouter: IntervalRouter, intervalItem: IntervalModel) -> IntervalDetailViewModel {
+    public func addIntervalDependencies(intervalRouter:IntervalRouter, intervalItem: IntervalModel) -> AddIntervalViewModelWithRouter {
+        let intervalDataSource = IntervalDataSource()
+        let intervalRepository = IntervalRepository(dataSource: intervalDataSource)
+        let intervalUseCase = IntervalUseCase(intervalRepository: intervalRepository)
+    
+        return AddIntervalViewModelWithRouter(
+            router: intervalRouter,
+            intervalUseCase: intervalUseCase,
+            intervalItem: intervalItem
+        )
+    }
+    
+    public func intervalDetailDependencies(intervalRouter: IntervalRouter, intervalItem: IntervalModel) -> IntervalDetailViewModelWithRouter {
         let intervalRecordDataSource = IntervalRecordDataSource()
         let intervalRecordRepository = IntervalRecordRepository(dataSource: intervalRecordDataSource)
         let intervalRecordUseCase = IntervalRecordUseCase(intervalRecordRepository: intervalRecordRepository)

--- a/Projects/App/iOS/Sources/DIContainer/IntervalDIContainer.swift
+++ b/Projects/App/iOS/Sources/DIContainer/IntervalDIContainer.swift
@@ -23,7 +23,7 @@ public final class IntervalDIContainer: IntervalDIContainerInterface {
         )
     }
     
-    public func intervalActiveDependencies(intervalRouter: IntervalRouter) -> IntervalActiveViewModel {
+    public func intervalActiveDependencies(intervalRouter: IntervalRouter) -> IntervalActiveViewModelWithRouter {
         let intervalDataSource = IntervalDataSource()
         let intervalRepository = IntervalRepository(dataSource: intervalDataSource)
         let intervalUseCase = IntervalUseCase(intervalRepository: intervalRepository)
@@ -34,7 +34,7 @@ public final class IntervalDIContainer: IntervalDIContainerInterface {
         )
     }
     
-    public func intervalListDependencies(intervalRouter: IntervalRouter) -> IntervalListViewModel {
+    public func intervalListDependencies(intervalRouter: IntervalRouter) -> IntervalListViewModelWithRouter {
         let intervalDataSource = IntervalDataSource()
         let intervalRepository = IntervalRepository(dataSource: intervalDataSource)
         let intervalUseCase = IntervalUseCase(intervalRepository: intervalRepository)
@@ -45,7 +45,7 @@ public final class IntervalDIContainer: IntervalDIContainerInterface {
         )
     }
     
-    public func addIntervalDependencies(intervalRouter: IntervalRouter) -> AddIntervalViewModel {
+    public func addIntervalDependencies(intervalRouter: IntervalRouter) -> AddIntervalViewModelWithRouter {
         let intervalDataSource = IntervalDataSource()
         let intervalRepository = IntervalRepository(dataSource: intervalDataSource)
         let intervalUseCase = IntervalUseCase(intervalRepository: intervalRepository)
@@ -53,7 +53,19 @@ public final class IntervalDIContainer: IntervalDIContainerInterface {
         return AddIntervalViewModelWithRouter(router: intervalRouter, intervalUseCase: intervalUseCase)
     }
     
-    public func intervalDetailDependencies(intervalRouter: IntervalRouter, intervalItem: IntervalModel) -> IntervalDetailViewModel {
+    public func addIntervalDependencies(intervalRouter:IntervalRouter, intervalItem: IntervalModel) -> AddIntervalViewModelWithRouter {
+        let intervalDataSource = IntervalDataSource()
+        let intervalRepository = IntervalRepository(dataSource: intervalDataSource)
+        let intervalUseCase = IntervalUseCase(intervalRepository: intervalRepository)
+    
+        return AddIntervalViewModelWithRouter(
+            router: intervalRouter,
+            intervalUseCase: intervalUseCase,
+            intervalItem: intervalItem
+        )
+    }
+    
+    public func intervalDetailDependencies(intervalRouter: IntervalRouter, intervalItem: IntervalModel) -> IntervalDetailViewModelWithRouter {
         let intervalRecordDataSource = IntervalRecordDataSource()
         let intervalRecordRepository = IntervalRecordRepository(dataSource: intervalRecordDataSource)
         let intervalRecordUseCase = IntervalRecordUseCase(intervalRecordRepository: intervalRecordRepository)

--- a/Projects/Data/Sources/Interval/DataSource/IntervalDataSource.swift
+++ b/Projects/Data/Sources/Interval/DataSource/IntervalDataSource.swift
@@ -111,7 +111,10 @@ public final class IntervalDataSource: IntervalDataSourceInterface {
     
     public func delete(at id: UUID) -> Bool {
         if let interval = self.fetch(id: id) {
-            self.context?.delete(interval)
+            interval.modelContext?.delete(interval)
+            
+            try? interval.modelContext?.save()
+    
             return true
         } else {
             return false

--- a/Projects/Presentation/Sources/Flows/Interval/IntervalDIContainerInterface.swift
+++ b/Projects/Presentation/Sources/Flows/Interval/IntervalDIContainerInterface.swift
@@ -9,8 +9,9 @@ import Foundation
 
 public protocol IntervalDIContainerInterface {
     func intervalScreenDependencies(intervalRouter: IntervalRouter) -> IntervalViewModel
-    func intervalListDependencies(intervalRouter: IntervalRouter) -> IntervalListViewModel
-    func intervalActiveDependencies(intervalRouter: IntervalRouter) -> IntervalActiveViewModel
-    func addIntervalDependencies(intervalRouter: IntervalRouter) -> AddIntervalViewModel
-    func intervalDetailDependencies(intervalRouter: IntervalRouter, intervalItem: IntervalModel) -> IntervalDetailViewModel
+    func intervalListDependencies(intervalRouter: IntervalRouter) -> IntervalListViewModelWithRouter
+    func intervalActiveDependencies(intervalRouter: IntervalRouter) -> IntervalActiveViewModelWithRouter
+    func addIntervalDependencies(intervalRouter: IntervalRouter) -> AddIntervalViewModelWithRouter
+    func addIntervalDependencies(intervalRouter: IntervalRouter, intervalItem: IntervalModel) -> AddIntervalViewModelWithRouter
+    func intervalDetailDependencies(intervalRouter: IntervalRouter, intervalItem: IntervalModel) -> IntervalDetailViewModelWithRouter
 }

--- a/Projects/Presentation/Sources/Flows/Interval/IntervalRouter.swift
+++ b/Projects/Presentation/Sources/Flows/Interval/IntervalRouter.swift
@@ -30,6 +30,10 @@ public final class IntervalRouter: ObservableObject, FlowRouter {
     public func nextTransitionScreen() -> some View {
         nextTransitionRoute.nextView(intervalDIContainer: self.intervalDIContainer, router: self)
     }
+    
+    public func sheetScreen(route: PushRoute) -> some View {
+        route.nextView(intervalDIContainer: self.intervalDIContainer, router: self)
+    }
 }
 
 public extension IntervalRouter {
@@ -37,6 +41,8 @@ public extension IntervalRouter {
         case intervalList
         case intervalDetail(IntervalModel)
         case intervalActive
+        case addInterval
+        case editInterval(IntervalModel)
        
         @ViewBuilder
         func nextView(intervalDIContainer: IntervalDIContainerInterface, router: IntervalRouter) -> some View {
@@ -50,6 +56,12 @@ public extension IntervalRouter {
             case .intervalActive:
                 let viewModel = intervalDIContainer.intervalActiveDependencies(intervalRouter: router)
                 IntervalActiveScreen(viewModel: viewModel)
+            case .addInterval:
+                let viewModel = intervalDIContainer.addIntervalDependencies(intervalRouter: router)
+                AddIntervalScreen(viewModel: viewModel)
+            case .editInterval(let intervalItem):
+                let viewModel = intervalDIContainer.addIntervalDependencies(intervalRouter: router, intervalItem: intervalItem)
+                AddIntervalScreen(viewModel: viewModel)
             }
         }
     }

--- a/Projects/Presentation/Sources/Flows/Interval/Screen/IntervalScreen+iOS.swift
+++ b/Projects/Presentation/Sources/Flows/Interval/Screen/IntervalScreen+iOS.swift
@@ -25,7 +25,9 @@ public extension IntervalScreen {
                 .navigationDestination(for: IntervalRouter.PushRoute.self) { _ in
                     viewModel.nextScreen()
                 }
-                .sheet(isPresented: $viewModel.isBottomSheetPresent) {
+                .sheet(isPresented: $viewModel.isBottomSheetPresent, 
+                       onDismiss: { viewModel.refreshScreen(screen: intervalListScreen) })
+                {
                     addIntervalScreen
                 }
         }

--- a/Projects/Presentation/Sources/Flows/Interval/ViewModel/IntervalViewModel.swift
+++ b/Projects/Presentation/Sources/Flows/Interval/ViewModel/IntervalViewModel.swift
@@ -33,4 +33,8 @@ public class IntervalViewModel: ObservableObject {
     public func nextScreen() -> some View {
         router.nextTransitionScreen()
     }
+    
+    func refreshScreen(screen: IntervalListScreen) {
+        screen.viewModel.fetchIntervalItems()
+    }
 }

--- a/Projects/Presentation/Sources/Interval/Add/AddIntervalScreen.swift
+++ b/Projects/Presentation/Sources/Interval/Add/AddIntervalScreen.swift
@@ -32,7 +32,9 @@ public struct AddIntervalScreen: View {
             }
             .padding(.horizontal, 30)
             .padding(.top, 10)
-            .navigationTitle("인터벌 추가")
+            .navigationTitle(
+                "인터벌 추가"
+            )
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {

--- a/Projects/Presentation/Sources/Interval/Add/AddIntervalViewModel.swift
+++ b/Projects/Presentation/Sources/Interval/Add/AddIntervalViewModel.swift
@@ -13,7 +13,7 @@ import Domain
 
 public class AddIntervalViewModelWithRouter: AddIntervalViewModel {
     private var router: IntervalRouter
-    
+
     public init(
         router: IntervalRouter,
         intervalUseCase: IntervalUseCaseInterface
@@ -22,14 +22,33 @@ public class AddIntervalViewModelWithRouter: AddIntervalViewModel {
         super.init(intervalUseCase: intervalUseCase)
     }
     
+    public init(
+        router: IntervalRouter,
+        intervalUseCase: IntervalUseCaseInterface,
+        intervalItem: IntervalModel
+    ) {
+        self.router = router
+        super.init(intervalUseCase: intervalUseCase, intervalItem: intervalItem)
+    }
+
+
     override func tapSaveButton() {
         super.tapSaveButton()
     }
-    
+
 }
 
 public class AddIntervalViewModel: ObservableObject {
     let intervalUseCase: IntervalUseCaseInterface
+    
+    @State var mode: Mode = .add
+    
+    enum Mode {
+        case add
+        case edit
+    }
+    
+    var selectedItemId: UUID? = nil
     
     @Published var name: String = ""
     @Published var repeatCounts : Int = 0
@@ -47,6 +66,23 @@ public class AddIntervalViewModel: ObservableObject {
         self.intervalUseCase = intervalUseCase
     }
     
+    public init(intervalUseCase: IntervalUseCaseInterface, intervalItem: IntervalModel) {
+        self.intervalUseCase = intervalUseCase
+        
+        self.mode = .edit
+        self.selectedItemId = intervalItem.id
+        
+        self.name = intervalItem.title
+        self.repeatCounts = intervalItem.repeatCount
+        
+        self.selectedExerciseType = intervalItem.exerciseType
+        
+        self.burningSelectedInterval = intervalItem.burningHeartIntervalType
+        self.burningTime = intervalItem.burningSecondTime
+        self.restingSelectedInterval = intervalItem.restingHeartIntervalType
+        self.restingTime = intervalItem.restingSecondTime
+    }
+    
     func tapSaveButton() {
         let newInterval = IntervalEntity(
             id: .init(),
@@ -60,7 +96,13 @@ public class AddIntervalViewModel: ObservableObject {
             records: []
         )
         
-        intervalUseCase.save(interval: newInterval)
+        switch self.mode {
+        case .add:
+            intervalUseCase.save(interval: newInterval)
+        case .edit:
+            intervalUseCase.update(at: self.selectedItemId!, to: newInterval)
+        }
+        
     }
-}
 
+}

--- a/Projects/Presentation/Sources/Interval/Add/Picker/BurningRestingPicker.swift
+++ b/Projects/Presentation/Sources/Interval/Add/Picker/BurningRestingPicker.swift
@@ -24,7 +24,6 @@ struct BurningRestingPicker: View {
     @State private var isTimeExpanded: Bool = false
     @State private var isSectionExpanded: Bool = false
     
-    
     var body: some View {
         VStack() {
             HStack {
@@ -39,10 +38,10 @@ struct BurningRestingPicker: View {
             .padding(.vertical,15)
             
             pickTimeView(hour: $hours, minute: $minutes, second: $seconds, isExpanded: $isTimeExpanded)
-                .onAppear(perform: calculateTime)
             
             pickIntervalView(selection: $selection, isExpanded: $isSectionExpanded)
         }
+        .onAppear(perform: calculateTime)
     }
     
     @ViewBuilder
@@ -84,6 +83,10 @@ struct BurningRestingPicker: View {
     
     private func calculateTime() {
         totalTime = hours * 3600 + minutes * 60 + seconds
+//        hours = totalTime / 3600
+//        minutes = totalTime % 3600 / 60
+//        seconds = totalTime % 60
+//        print(totalTime)
     }
     
     @ViewBuilder

--- a/Projects/Presentation/Sources/Interval/List/Screen/Cell/IntervalInfoCellView.swift
+++ b/Projects/Presentation/Sources/Interval/List/Screen/Cell/IntervalInfoCellView.swift
@@ -45,7 +45,7 @@ public struct IntervalInfoCellView: View {
             toolButton(imageName: "pencil", 
                        color: .editColor,
                        backgroundColor: .editColor) {
-                intervalListViewModel.tapIntervalEditButton()
+                intervalListViewModel.tapIntervalEditButton(selectedItem: intervalItem)
             }
             
             Spacer()

--- a/Projects/Presentation/Sources/Interval/List/Screen/IntervalListScreen.swift
+++ b/Projects/Presentation/Sources/Interval/List/Screen/IntervalListScreen.swift
@@ -12,9 +12,9 @@ import Domain
 import SharedDesignSystem
 
 public struct IntervalListScreen: View {
-    @StateObject var viewModel: IntervalListViewModel
+    @StateObject var viewModel: IntervalListViewModelWithRouter
     
-    public init(viewModel: IntervalListViewModel) {
+    public init(viewModel: IntervalListViewModelWithRouter) {
         self._viewModel = .init(wrappedValue: viewModel)
     }
     

--- a/Projects/Presentation/Sources/Interval/List/Screen/iOS/IntervalListIPhoneScreen.swift
+++ b/Projects/Presentation/Sources/Interval/List/Screen/iOS/IntervalListIPhoneScreen.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import SharedDesignSystem
 
 public struct IntervalListIPhoneScreen: View {
-    @ObservedObject var viewModel: IntervalListViewModel
+    @ObservedObject var viewModel: IntervalListViewModelWithRouter
     
     public var body: some View {
         ScrollView {
@@ -23,9 +23,9 @@ public struct IntervalListIPhoneScreen: View {
             .padding(.top, 32)
         }
         .mainBackground()
-        .sheet(isPresented: $viewModel.showEditIntervalView, content: {
-            EditIntervalScreen()
-        })
+        .sheet(isPresented: $viewModel.showEditIntervalView, onDismiss: viewModel.fetchIntervalItems){
+            viewModel.editIntervalScreen(selectedItem: viewModel.selectedItem!)
+        }
         .onAppear {
             viewModel.fetchIntervalItems()
         }

--- a/Projects/Presentation/Sources/Interval/List/ViewModel/IntervalListViewModel.swift
+++ b/Projects/Presentation/Sources/Interval/List/ViewModel/IntervalListViewModel.swift
@@ -30,6 +30,10 @@ public class IntervalListViewModelWithRouter: IntervalListViewModel {
         super.tapIntervalDetailPageButton(intervalItem: intervalItem)
         router.triggerScreenTransition(route: .intervalDetail(intervalItem))
     }
+    
+    func editIntervalScreen(selectedItem: IntervalModel) -> some View {
+        return router.sheetScreen(route: .editInterval(selectedItem))
+    }
 }
 
 
@@ -38,6 +42,7 @@ public class IntervalListViewModel: ObservableObject {
     
     @Published var intervalItems: [IntervalModel] = []
     @Published var showEditIntervalView: Bool = false
+    @Published var selectedItem: IntervalModel? = nil
     
     public init(intervalUseCase: IntervalUseCaseInterface) {
         self.intervalUseCase = intervalUseCase
@@ -55,9 +60,12 @@ public class IntervalListViewModel: ObservableObject {
     
     func tapIntervalDeleteButton(at id: UUID) {
         let _ = intervalUseCase.delete(at: id)
+        
+        self.fetchIntervalItems()
     }
     
-    func tapIntervalEditButton() {
+    func tapIntervalEditButton(selectedItem: IntervalModel) {
         showEditIntervalView = true
+        self.selectedItem = selectedItem
     }
 }


### PR DESCRIPTION
## PR 요약
1. addScreen에서 저장 버튼을 누르면 intervalListViewModel이 리프레쉬 됩니다.
2. 수정 버튼을 누르면 addSreen이 열립니다.

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->

##### ✅ PR check list
편집 버튼을 눌렀을 때 addIntervalScreen 띄우는 부분 피드백 받고 싶습니다 !! 
이부분 시트가 intervalListScreen에 속해 있어서 먼저 DI컨테이너와 라우터를 넘겨 받아 객체를 새로 생성하는 방식을 생각했었는데 코드가 지저분 해지는 것 같아,, intervalListViewmodel의 라우터를 사용하고자 했습니다,,! 

+) 뷰모델을 사용해서 뷰를 반환하고자 하니 intervalListViewmodelWithRouter 에서 메소드 오버라이딩할 때 문제가 생겨서 우선 WithRouter뷰모델을 사용했습니다,, 

#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
close #24 


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->