### PR TITLE
[Feat/#28] MVVM 리펙토링

### DIFF
--- a/Projects/App/WatchExtension/Sources/DIContainer/IntervalDIContainer.swift
+++ b/Projects/App/WatchExtension/Sources/DIContainer/IntervalDIContainer.swift
@@ -6,13 +6,13 @@
 //
 
 import Foundation
+import SwiftUI
 
 import Presentation
 import Domain
 import Data
 
 public final class IntervalDIContainer: IntervalDIContainerInterface {
-    
     public func intervalRouter() -> IntervalRouter {
         return IntervalRouter(intervalDIContainer: self)
     }
@@ -50,16 +50,7 @@ public final class IntervalDIContainer: IntervalDIContainerInterface {
         )
     }
     
-    public func addIntervalDependencies(intervalRouter: IntervalRouter) -> AddIntervalViewModelWithRouter {
-        let intervalDataSource = IntervalDataSource()
-        let intervalRepository = IntervalRepository(dataSource: intervalDataSource)
-        let intervalUseCase = IntervalUseCase(intervalRepository: intervalRepository)
-    
-        return AddIntervalViewModelWithRouter(router: intervalRouter, intervalUseCase: intervalUseCase)
-
-    }
-    
-    public func addIntervalDependencies(intervalRouter:IntervalRouter, intervalItem: IntervalModel) -> AddIntervalViewModelWithRouter {
+    public func addIntervalDependencies(intervalRouter: IntervalRouter, intervalItem: Binding<IntervalModel>?) -> AddIntervalViewModel {
         let intervalDataSource = IntervalDataSource()
         let intervalRepository = IntervalRepository(dataSource: intervalDataSource)
         let intervalUseCase = IntervalUseCase(intervalRepository: intervalRepository)
@@ -70,7 +61,7 @@ public final class IntervalDIContainer: IntervalDIContainerInterface {
             intervalItem: intervalItem
         )
     }
-    
+
     public func intervalDetailDependencies(intervalRouter: IntervalRouter, intervalItem: IntervalModel) -> IntervalDetailViewModelWithRouter {
         let intervalRecordDataSource = IntervalRecordDataSource()
         let intervalRecordRepository = IntervalRecordRepository(dataSource: intervalRecordDataSource)

--- a/Projects/App/iOS/Sources/DIContainer/IntervalDIContainer.swift
+++ b/Projects/App/iOS/Sources/DIContainer/IntervalDIContainer.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 import Presentation
 import Domain
@@ -45,15 +46,7 @@ public final class IntervalDIContainer: IntervalDIContainerInterface {
         )
     }
     
-    public func addIntervalDependencies(intervalRouter: IntervalRouter) -> AddIntervalViewModelWithRouter {
-        let intervalDataSource = IntervalDataSource()
-        let intervalRepository = IntervalRepository(dataSource: intervalDataSource)
-        let intervalUseCase = IntervalUseCase(intervalRepository: intervalRepository)
-        
-        return AddIntervalViewModelWithRouter(router: intervalRouter, intervalUseCase: intervalUseCase)
-    }
-    
-    public func addIntervalDependencies(intervalRouter:IntervalRouter, intervalItem: IntervalModel) -> AddIntervalViewModelWithRouter {
+    public func addIntervalDependencies(intervalRouter:IntervalRouter, intervalItem: Binding<IntervalModel>?) -> AddIntervalViewModel {
         let intervalDataSource = IntervalDataSource()
         let intervalRepository = IntervalRepository(dataSource: intervalDataSource)
         let intervalUseCase = IntervalUseCase(intervalRepository: intervalRepository)

--- a/Projects/Domain/Sources/Interval/UseCase/IntervalUseCase.swift
+++ b/Projects/Domain/Sources/Interval/UseCase/IntervalUseCase.swift
@@ -11,8 +11,8 @@ import Combine
 public protocol IntervalUseCaseInterface {
     func fetch(id: UUID) -> IntervalEntity?
     func fetches() -> [IntervalEntity]
-    func save(interval: IntervalEntity) -> Bool
-    func update(at id: UUID, to interval: IntervalEntity) -> IntervalEntity?
+    @discardableResult func save(interval: IntervalEntity) -> Bool
+    @discardableResult func update(at id: UUID, to interval: IntervalEntity) -> IntervalEntity?
     func delete(at id: UUID) -> Bool
 }
 

--- a/Projects/Presentation/Sources/Flows/FlowRouter.swift
+++ b/Projects/Presentation/Sources/Flows/FlowRouter.swift
@@ -9,17 +9,24 @@ import Foundation
 import SwiftUI
 
 public protocol FlowRouter: Hashable {
-    associatedtype PushRoute: Hashable
-    associatedtype NextScreen: View
+    associatedtype NavigationRoute: Hashable
+    associatedtype PresentationRoute: Identifiable
+    associatedtype NavigationScreen: View
+    associatedtype PresentationScreen: View
 
     var id: UUID { get }
 
     var navigationPath: NavigationPath { get set }
 
-    var nextTransitionRoute: PushRoute { get }
+    var nextNavigationRoute: NavigationRoute { get }
+    var nextPresentationRoute: PresentationRoute? { get }
 
-    func triggerScreenTransition(route: PushRoute)
-    func nextTransitionScreen() -> NextScreen
+    func triggerNavigationScreen(navigationRoute: NavigationRoute)
+    func triggerPresentationScreen(presentationRoute: PresentationRoute?)
+
+    func nextNavigationScreen() -> NavigationScreen
+    func nextPresentationScreen() -> PresentationScreen
+
 }
 
 public extension FlowRouter {

--- a/Projects/Presentation/Sources/Flows/Interval/IntervalDIContainerInterface.swift
+++ b/Projects/Presentation/Sources/Flows/Interval/IntervalDIContainerInterface.swift
@@ -6,12 +6,12 @@
 //
 
 import Foundation
+import SwiftUI
 
 public protocol IntervalDIContainerInterface {
     func intervalScreenDependencies(intervalRouter: IntervalRouter) -> IntervalViewModel
     func intervalListDependencies(intervalRouter: IntervalRouter) -> IntervalListViewModelWithRouter
     func intervalActiveDependencies(intervalRouter: IntervalRouter) -> IntervalActiveViewModelWithRouter
-    func addIntervalDependencies(intervalRouter: IntervalRouter) -> AddIntervalViewModelWithRouter
-    func addIntervalDependencies(intervalRouter: IntervalRouter, intervalItem: IntervalModel) -> AddIntervalViewModelWithRouter
+    func addIntervalDependencies(intervalRouter: IntervalRouter, intervalItem: Binding<IntervalModel>?) -> AddIntervalViewModel
     func intervalDetailDependencies(intervalRouter: IntervalRouter, intervalItem: IntervalModel) -> IntervalDetailViewModelWithRouter
 }

--- a/Projects/Presentation/Sources/Flows/Interval/Screen/IntervalScreen+iOS.swift
+++ b/Projects/Presentation/Sources/Flows/Interval/Screen/IntervalScreen+iOS.swift
@@ -25,7 +25,7 @@ public extension IntervalScreen {
                 .navigationDestination(for: IntervalRouter.NavigationRoute.self) { _ in
                     viewModel.nextScreen()
                 }
-                .sheetWithRouter(router: self.$router)
+                .sheetWithRouter(router: self.router)
         }
         .tint(Color.keyColor)
     }

--- a/Projects/Presentation/Sources/Flows/Interval/Screen/IntervalScreen+iOS.swift
+++ b/Projects/Presentation/Sources/Flows/Interval/Screen/IntervalScreen+iOS.swift
@@ -16,20 +16,16 @@ public extension IntervalScreen {
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
                         Button(action: {
-                            viewModel.isBottomSheetPresent = true
+                            viewModel.tapPlusButton()
                         }, label: {
                             Image(systemName: "plus")
                         })
                     }
                 }
-                .navigationDestination(for: IntervalRouter.PushRoute.self) { _ in
+                .navigationDestination(for: IntervalRouter.NavigationRoute.self) { _ in
                     viewModel.nextScreen()
                 }
-                .sheet(isPresented: $viewModel.isBottomSheetPresent, 
-                       onDismiss: { viewModel.refreshScreen(screen: intervalListScreen) })
-                {
-                    addIntervalScreen
-                }
+                .sheetWithRouter(router: self.$router)
         }
         .tint(Color.keyColor)
     }

--- a/Projects/Presentation/Sources/Flows/Interval/Screen/IntervalScreen+watchOS.swift
+++ b/Projects/Presentation/Sources/Flows/Interval/Screen/IntervalScreen+watchOS.swift
@@ -23,7 +23,7 @@ public extension IntervalScreen {
                 }
             }
             .navigationTitle("인터레스트")
-            .navigationDestination(for: IntervalRouter.PushRoute.self) { _ in
+            .navigationDestination(for: IntervalRouter.NavigationRoute.self) { _ in
                 viewModel.nextScreen()
             }
         }

--- a/Projects/Presentation/Sources/Flows/Interval/Screen/IntervalScreen.swift
+++ b/Projects/Presentation/Sources/Flows/Interval/Screen/IntervalScreen.swift
@@ -10,11 +10,12 @@ import Domain
 import SharedDesignSystem
 
 public struct IntervalScreen: View {
-    @StateObject var router: IntervalRouter
-    @StateObject var viewModel: IntervalViewModel
-    
+    let intervalDIContainer: IntervalDIContainerInterface
+    @State var router: IntervalRouter
+    @State var viewModel: IntervalViewModel
+
     let intervalListScreen: IntervalListScreen
-    let addIntervalScreen: AddIntervalScreen
+//    let addIntervalScreen: AddIntervalScreen
     
     public init(
         intervalDIContainer: IntervalDIContainerInterface,
@@ -22,12 +23,13 @@ public struct IntervalScreen: View {
     ) {
         let router = routerDIContainer.intervalRouter(intervalDIContainer: intervalDIContainer)
         
+        self.intervalDIContainer = intervalDIContainer
         self._router = .init(wrappedValue: router)
         self._viewModel = .init(wrappedValue: intervalDIContainer.intervalScreenDependencies(intervalRouter: router))
         
         self.intervalListScreen = .init(viewModel: intervalDIContainer.intervalListDependencies(intervalRouter: router))
         
-        self.addIntervalScreen = .init(viewModel: intervalDIContainer.addIntervalDependencies(intervalRouter: router))
+//        self.addIntervalScreen = .init(viewModel: intervalDIContainer.addIntervalDependencies(intervalRouter: router))
                 
 #if os(iOS)
         UIRefreshControl.appearance().tintColor = UIColor(Color.keyColor)

--- a/Projects/Presentation/Sources/Flows/Interval/ViewModel/IntervalViewModel.swift
+++ b/Projects/Presentation/Sources/Flows/Interval/ViewModel/IntervalViewModel.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 import Domain
 
-public class IntervalViewModel: ObservableObject {
+@Observable public final class IntervalViewModel {
     private let router: IntervalRouter
     private let intervalUseCase: IntervalUseCaseInterface
     
-    @Published public var isBottomSheetPresent = false
+    public var isBottomSheetPresent = false
     
     public init(
         router: IntervalRouter,
@@ -21,20 +21,16 @@ public class IntervalViewModel: ObservableObject {
         self.router = router
         self.intervalUseCase = intervalUseCase
     }
-    
-    func tapIntervalStartButton(item: IntervalModel) {
-        router.triggerScreenTransition(route: .intervalActive)
+
+    public func tapPlusButton() {
+        router.triggerPresentationScreen(presentationRoute: .addInterval)
     }
-    
-    func triggerTransition(route: IntervalRouter.PushRoute) {
-        router.triggerScreenTransition(route: route)
+
+    public func tapIntervalStartButton(item: IntervalModel) {
+        router.triggerNavigationScreen(navigationRoute: .intervalActive)
     }
-    
+
     public func nextScreen() -> some View {
-        router.nextTransitionScreen()
-    }
-    
-    func refreshScreen(screen: IntervalListScreen) {
-        screen.viewModel.fetchIntervalItems()
+        router.nextNavigationScreen()
     }
 }

--- a/Projects/Presentation/Sources/Flows/SheetWithRouter.swift
+++ b/Projects/Presentation/Sources/Flows/SheetWithRouter.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct SheetWithRouterViewModifier<Router: FlowRouter>: ViewModifier {
-    @Binding var router: Router
+    var router: Router
 
     @ViewBuilder func body(content: Content) -> some View {
         content
@@ -31,7 +31,7 @@ struct SheetWithRouterViewModifier<Router: FlowRouter>: ViewModifier {
 
 extension View {
     @ViewBuilder 
-    func sheetWithRouter<Router: FlowRouter>(router: Binding<Router>) -> some View {
+    func sheetWithRouter<Router: FlowRouter>(router: Router) -> some View {
         self.modifier(SheetWithRouterViewModifier(router: router))
     }
 }

--- a/Projects/Presentation/Sources/Flows/SheetWithRouter.swift
+++ b/Projects/Presentation/Sources/Flows/SheetWithRouter.swift
@@ -1,0 +1,37 @@
+//
+//  SheetWithRouter.swift
+//  Presentation
+//
+//  Created by 송영모 on 1/20/24.
+//
+
+import Foundation
+import SwiftUI
+
+struct SheetWithRouterViewModifier<Router: FlowRouter>: ViewModifier {
+    @Binding var router: Router
+
+    @ViewBuilder func body(content: Content) -> some View {
+        content
+            .sheet(
+                isPresented: .init(
+                    get: { router.nextPresentationRoute != nil },
+                    set: { isPresented in
+                        if !isPresented {
+                            router.triggerPresentationScreen(presentationRoute: nil)
+                        }
+                    }
+                )
+            ) {
+                self.router.nextPresentationScreen()
+            }
+    }
+}
+
+
+extension View {
+    @ViewBuilder 
+    func sheetWithRouter<Router: FlowRouter>(router: Binding<Router>) -> some View {
+        self.modifier(SheetWithRouterViewModifier(router: router))
+    }
+}

--- a/Projects/Presentation/Sources/Interval/Add/AddIntervalScreen.swift
+++ b/Projects/Presentation/Sources/Interval/Add/AddIntervalScreen.swift
@@ -15,10 +15,10 @@ public struct AddIntervalScreen: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) var colorScheme: ColorScheme
     
-    @StateObject var viewModel: AddIntervalViewModel
+    @State var viewModel: AddIntervalViewModel
     
     public init(viewModel: AddIntervalViewModel) {
-        self._viewModel = StateObject(wrappedValue: viewModel)
+        self._viewModel = .init(wrappedValue: viewModel)
     }
     
     public var body: some View {
@@ -63,7 +63,7 @@ public struct AddIntervalScreen: View {
                     .fontWeight(.semibold)
                 Spacer()
             }
-            TextField("달리기 인터벌", text: $viewModel.name)
+            TextField("달리기 인터벌", text: viewModel.intervalItem.title)
                 .padding(.all,12)
                 .background(colorScheme == .dark ? Color.textColor25 : Color.textColor75)
                 .cornerRadius(10)
@@ -72,22 +72,22 @@ public struct AddIntervalScreen: View {
     }
     private var exercise: some View {
         HStack{
-            ExercisePickerView(selectedExerciseType: $viewModel.selectedExerciseType)
+            ExercisePickerView(selectedExerciseType: viewModel.intervalItem.exerciseType)
         }
         .padding(.vertical,10)
     }
     
     private var repeatCount: some View {
         VStack{
-            RepeatPicker(isRepeat: false, repeatCount: $viewModel.repeatCounts)
+            RepeatPicker(isRepeat: false, repeatCount: viewModel.intervalItem.repeatCount)
         }
     }
     
     private var burningResting: some View {
         VStack{
-            BurningRestingPicker(isBurning: true, selection: $viewModel.burningSelectedInterval, totalTime: $viewModel.burningTime)
-            
-            BurningRestingPicker(isBurning: false, selection: $viewModel.restingSelectedInterval, totalTime: $viewModel.restingTime)
+            BurningRestingPicker(isBurning: true, selection: viewModel.intervalItem.burningHeartIntervalType, totalTime: viewModel.intervalItem.burningSecondTime)
+
+            BurningRestingPicker(isBurning: false, selection: viewModel.intervalItem.restingHeartIntervalType, totalTime: viewModel.intervalItem.restingSecondTime)
         }
     }
 }

--- a/Projects/Presentation/Sources/Interval/Add/AddIntervalViewModel.swift
+++ b/Projects/Presentation/Sources/Interval/Add/AddIntervalViewModel.swift
@@ -26,6 +26,8 @@ import Domain
 
     override func tapSaveButton() {
         super.tapSaveButton()
+
+        router.triggerPresentationScreen(presentationRoute: nil)
     }
 
 }

--- a/Projects/Presentation/Sources/Interval/Add/Picker/ExercisePicker.swift
+++ b/Projects/Presentation/Sources/Interval/Add/Picker/ExercisePicker.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct ExercisePickerView: View {
-    @Binding var selectedExerciseType: ExerciseTypeModel?
+    @Binding var selectedExerciseType: ExerciseTypeModel
     
     var body: some View {
         pickerView

--- a/Projects/Presentation/Sources/Interval/List/Screen/Cell/IntervalInfoCellView.swift
+++ b/Projects/Presentation/Sources/Interval/List/Screen/Cell/IntervalInfoCellView.swift
@@ -11,8 +11,8 @@ import SwiftUI
 import SharedDesignSystem
 
 public struct IntervalInfoCellView: View {
-    @ObservedObject private var intervalListViewModel: IntervalListViewModel
-    
+    private var intervalListViewModel: IntervalListViewModel
+
     @State private var cellOffsetX = CGFloat.zero
     
     public var intervalItem: IntervalModel

--- a/Projects/Presentation/Sources/Interval/List/Screen/Cell/IntervalInfoCellView.swift
+++ b/Projects/Presentation/Sources/Interval/List/Screen/Cell/IntervalInfoCellView.swift
@@ -15,11 +15,11 @@ public struct IntervalInfoCellView: View {
 
     @State private var cellOffsetX = CGFloat.zero
     
-    public var intervalItem: IntervalModel
-    
+    @State var intervalItem: IntervalModel
+
     init(intervalItem: IntervalModel, intervalListViewModel: IntervalListViewModel) {
-        self.intervalItem = intervalItem
         self.intervalListViewModel = intervalListViewModel
+        self._intervalItem = .init(wrappedValue: intervalItem)
     }
     
     public var body: some View {
@@ -44,8 +44,9 @@ public struct IntervalInfoCellView: View {
             
             toolButton(imageName: "pencil", 
                        color: .editColor,
-                       backgroundColor: .editColor) {
-                intervalListViewModel.tapIntervalEditButton(selectedItem: intervalItem)
+                       backgroundColor: .editColor
+            ) {
+                intervalListViewModel.tapIntervalEditButton(selectedItem: $intervalItem)
             }
             
             Spacer()

--- a/Projects/Presentation/Sources/Interval/List/Screen/IntervalListScreen.swift
+++ b/Projects/Presentation/Sources/Interval/List/Screen/IntervalListScreen.swift
@@ -12,8 +12,8 @@ import Domain
 import SharedDesignSystem
 
 public struct IntervalListScreen: View {
-    @StateObject var viewModel: IntervalListViewModelWithRouter
-    
+    @State var viewModel: IntervalListViewModelWithRouter
+
     public init(viewModel: IntervalListViewModelWithRouter) {
         self._viewModel = .init(wrappedValue: viewModel)
     }

--- a/Projects/Presentation/Sources/Interval/List/Screen/WatchOS/IntervalListWatchScreen.swift
+++ b/Projects/Presentation/Sources/Interval/List/Screen/WatchOS/IntervalListWatchScreen.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 public struct IntervalListWatchScreen: View {
-    @ObservedObject var viewModel: IntervalListViewModel
+    @State var viewModel: IntervalListViewModel
     
     public var body: some View {
         ScrollView(.horizontal) {

--- a/Projects/Presentation/Sources/Interval/List/Screen/iOS/IntervalListIPhoneScreen.swift
+++ b/Projects/Presentation/Sources/Interval/List/Screen/iOS/IntervalListIPhoneScreen.swift
@@ -10,8 +10,8 @@ import SwiftUI
 import SharedDesignSystem
 
 public struct IntervalListIPhoneScreen: View {
-    @ObservedObject var viewModel: IntervalListViewModelWithRouter
-    
+    @State var viewModel: IntervalListViewModelWithRouter
+
     public var body: some View {
         ScrollView {
             LazyVStack(spacing: 24) {
@@ -23,9 +23,10 @@ public struct IntervalListIPhoneScreen: View {
             .padding(.top, 32)
         }
         .mainBackground()
-        .sheet(isPresented: $viewModel.showEditIntervalView, onDismiss: viewModel.fetchIntervalItems){
-            viewModel.editIntervalScreen(selectedItem: viewModel.selectedItem!)
-        }
+//        .sheet(isPresented: $viewModel.isShowEditIntervalView){
+//            viewModel.editIntervalScreen(selectedItem: viewModel.selectedItem!)
+//            AddIntervalScreen(viewModel: .init(intervalUseCase: <#T##IntervalUseCaseInterface#>))
+//        }
         .onAppear {
             viewModel.fetchIntervalItems()
         }

--- a/Projects/Presentation/Sources/Interval/List/Screen/iOS/IntervalListIPhoneScreen.swift
+++ b/Projects/Presentation/Sources/Interval/List/Screen/iOS/IntervalListIPhoneScreen.swift
@@ -23,10 +23,6 @@ public struct IntervalListIPhoneScreen: View {
             .padding(.top, 32)
         }
         .mainBackground()
-//        .sheet(isPresented: $viewModel.isShowEditIntervalView){
-//            viewModel.editIntervalScreen(selectedItem: viewModel.selectedItem!)
-//            AddIntervalScreen(viewModel: .init(intervalUseCase: <#T##IntervalUseCaseInterface#>))
-//        }
         .onAppear {
             viewModel.fetchIntervalItems()
         }

--- a/Projects/Presentation/Sources/Interval/List/ViewModel/IntervalListViewModel.swift
+++ b/Projects/Presentation/Sources/Interval/List/ViewModel/IntervalListViewModel.swift
@@ -10,40 +10,14 @@ import SwiftUI
 
 import Domain
 
-public class IntervalListViewModelWithRouter: IntervalListViewModel {
-    private var router: IntervalRouter
-    
-    public init(
-        router: IntervalRouter,
-        intervalUseCase: IntervalUseCaseInterface
-    ) {
-        self.router = router
-        super.init(intervalUseCase: intervalUseCase)
-    }
-    
-    override func tapStartButton() {
-        super.tapStartButton()
-        router.triggerScreenTransition(route: .intervalActive)
-    }
-    
-    override func tapIntervalDetailPageButton(intervalItem: IntervalModel) {
-        super.tapIntervalDetailPageButton(intervalItem: intervalItem)
-        router.triggerScreenTransition(route: .intervalDetail(intervalItem))
-    }
-    
-    func editIntervalScreen(selectedItem: IntervalModel) -> some View {
-        return router.sheetScreen(route: .editInterval(selectedItem))
-    }
-}
-
-
-public class IntervalListViewModel: ObservableObject {
+@Observable public class IntervalListViewModel {
     private let intervalUseCase: IntervalUseCaseInterface
     
-    @Published var intervalItems: [IntervalModel] = []
-    @Published var showEditIntervalView: Bool = false
-    @Published var selectedItem: IntervalModel? = nil
-    
+    var intervalItems: [IntervalModel] = []
+    var selectedItem: IntervalModel? = nil
+
+    var isShowEditIntervalView: Bool = false
+
     public init(intervalUseCase: IntervalUseCaseInterface) {
         self.intervalUseCase = intervalUseCase
     }
@@ -65,7 +39,7 @@ public class IntervalListViewModel: ObservableObject {
     }
     
     func tapIntervalEditButton(selectedItem: IntervalModel) {
-        showEditIntervalView = true
+        isShowEditIntervalView = true
         self.selectedItem = selectedItem
     }
 }

--- a/Projects/Presentation/Sources/Interval/List/ViewModel/IntervalListViewModel.swift
+++ b/Projects/Presentation/Sources/Interval/List/ViewModel/IntervalListViewModel.swift
@@ -14,9 +14,7 @@ import Domain
     private let intervalUseCase: IntervalUseCaseInterface
     
     var intervalItems: [IntervalModel] = []
-    var selectedItem: IntervalModel? = nil
-
-    var isShowEditIntervalView: Bool = false
+//    var selectedItem: IntervalModel? = nil
 
     public init(intervalUseCase: IntervalUseCaseInterface) {
         self.intervalUseCase = intervalUseCase
@@ -38,8 +36,7 @@ import Domain
         self.fetchIntervalItems()
     }
     
-    func tapIntervalEditButton(selectedItem: IntervalModel) {
-        isShowEditIntervalView = true
-        self.selectedItem = selectedItem
+    func tapIntervalEditButton(selectedItem: Binding<IntervalModel>) {
+//        self.selectedItem = selectedItem
     }
 }

--- a/Projects/Presentation/Sources/Interval/List/ViewModel/IntervalListViewModelWithRouter.swift
+++ b/Projects/Presentation/Sources/Interval/List/ViewModel/IntervalListViewModelWithRouter.swift
@@ -1,0 +1,38 @@
+//
+//  IntervalListViewModelWithRouter.swift
+//  Presentation
+//
+//  Created by 송영모 on 1/20/24.
+//
+
+import Foundation
+import SwiftUI
+
+import Domain
+
+@Observable public final class IntervalListViewModelWithRouter: IntervalListViewModel {
+    private var router: IntervalRouter
+
+    public init(
+        router: IntervalRouter,
+        intervalUseCase: IntervalUseCaseInterface
+    ) {
+        self.router = router
+        super.init(intervalUseCase: intervalUseCase)
+    }
+
+    override func tapStartButton() {
+        super.tapStartButton()
+        router.triggerNavigationScreen(navigationRoute: .intervalActive)
+    }
+
+    override func tapIntervalDetailPageButton(intervalItem: IntervalModel) {
+        super.tapIntervalDetailPageButton(intervalItem: intervalItem)
+        router.triggerNavigationScreen(navigationRoute: .intervalDetail(intervalItem))
+    }
+
+    func editIntervalScreen(selectedItem: IntervalModel) -> some View {
+        return router.nextPresentationScreen()
+//        return router.sheetScreen(route: .editInterval(selectedItem))
+    }
+}

--- a/Projects/Presentation/Sources/Interval/List/ViewModel/IntervalListViewModelWithRouter.swift
+++ b/Projects/Presentation/Sources/Interval/List/ViewModel/IntervalListViewModelWithRouter.swift
@@ -31,6 +31,11 @@ import Domain
         router.triggerNavigationScreen(navigationRoute: .intervalDetail(intervalItem))
     }
 
+    override func tapIntervalEditButton(selectedItem: Binding<IntervalModel>) {
+        super.tapIntervalEditButton(selectedItem: selectedItem)
+        router.triggerPresentationScreen(presentationRoute: .editInterval(selectedItem))
+    }
+
     func editIntervalScreen(selectedItem: IntervalModel) -> some View {
         return router.nextPresentationScreen()
 //        return router.sheetScreen(route: .editInterval(selectedItem))

--- a/Projects/Presentation/Sources/Interval/Model/IntervalModel.swift
+++ b/Projects/Presentation/Sources/Interval/Model/IntervalModel.swift
@@ -8,10 +8,10 @@
 import Foundation
 import Domain
 
-public struct IntervalModel: Identifiable, Hashable {
+public struct IntervalModel: Identifiable, Hashable, Equatable {
     public var id: UUID
     
-    public let title: String
+    public var title: String
     
     public var exerciseType: ExerciseTypeModel
     
@@ -24,9 +24,9 @@ public struct IntervalModel: Identifiable, Hashable {
     public var records: [IntervalRecordModel]
     
     public init(
-        id: UUID,
+        id: UUID = .init(),
         title: String = "",
-        exerciseType: ExerciseTypeModel,
+        exerciseType: ExerciseTypeModel = .run,
         burningSecondTime: Int = 0,
         burningHeartIntervalType: HeartIntervalTypeModel = .three,
         restingSecondTime: Int = 0,

--- a/Projects/Presentation/Sources/Interval/Model/IntervalModel.swift
+++ b/Projects/Presentation/Sources/Interval/Model/IntervalModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Domain
 
-public struct IntervalModel: Identifiable, Hashable, Equatable {
+public struct IntervalModel: Identifiable, Hashable {
     public var id: UUID
     
     public var title: String


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->

<img src="https://github.com/TEAM-ALOM/interest-iOS/assets/77970826/5c7ea40d-4e1e-49a2-910b-402e081b03af" width="30%">

### FlowRouter 변경사항

```swift
public protocol FlowRouter: Hashable {
    associatedtype NavigationRoute: Hashable
    associatedtype PresentationRoute: Identifiable
    associatedtype NavigationScreen: View
    associatedtype PresentationScreen: View
    var id: UUID { get }

    var navigationPath: NavigationPath { get set }

    var nextNavigationRoute: NavigationRoute { get }
    var nextPresentationRoute: PresentationRoute? { get }

    func triggerNavigationScreen(navigationRoute: NavigationRoute)
    func triggerPresentationScreen(presentationRoute: PresentationRoute?)

    func nextNavigationScreen() -> NavigationScreen
    func nextPresentationScreen() -> PresentationScreen
```

기존에 Navigation과 Present Route가 혼재되어있었습니다. Route Enum은 navigationScreen에 무조건 path를 추가하여서 이제는 navigationPath를 사용하지 않는 케이스에 대한 고려가 필요했고 저희는 isBottomSheet 이런식으로 처리하다보니까 드는 의문점은 이럴거면 왜 FlowRouter을 사용하는거지? 라는 의문이 들어서 모든 라우팅 처리를 FlowRouter로 변경하였고, @ShapeKim98 님이 지난번 PR에서 남겨주신 댓글을 고민을 열심히 해본결과 Root 단에서 Sheet을 관리하는 것으로 변경하였습니다. 중간중간에 부모와 자식간의 바인딩 처리가 필요했는데 SwiftUI에 의존하는 Binding을 사용해서 구현을 하였는데, 이부분이 애매한 것 같습니다.. 피드백 주시면 감사하겠습니다.

### SheeWithRouter 모디파이어 추가

```swift
struct SheetWithRouterViewModifier<Router: FlowRouter>: ViewModifier {
    @Binding var router: Router
    @ViewBuilder func body(content: Content) -> some View {
        content
            .sheet(
                isPresented: .init(
                    get: { router.nextPresentationRoute != nil },
                    set: { isPresented in
                        if !isPresented {
                            router.triggerPresentationScreen(presentationRoute: nil)
                        }
                    }
                )
            ) {
                self.router.nextPresentationScreen()
            }
    }
}


extension View {
    @ViewBuilder 
    func sheetWithRouter<Router: FlowRouter>(router: Binding<Router>) -> some View {
        self.modifier(SheetWithRouterViewModifier(router: router))
    }
}
```
사실 이 모디파이어를 추가하기 위해 이런 짓을 하였습니다. flowRouter의 presentationRoute를 관찰하고 있다가 알아서 바텀시트가 띄워졌으면 했습니다. Root단에 한번만 router와 함께 달아주면 모든 Sheet가 Root에서 관리될 수 있습니다. router의 함수인 triggerPresentation을 호출하면 알아서 바텀시트가 띄워지도록 설계하였습니다. 


### Observable로 변경

https://developer.apple.com/documentation/swiftui/migrating-from-the-observable-object-protocol-to-the-observable-macro
이거는 최근에 알게 되었는데요.. ObserableObject를 사용하지 말아야 하는 이유는 Published 객체를 모두 관찰하고 있다가 뷰를 업데이트 시키는데, 업데이트가 불필요한 화면도 업데이트를 하기 때문에 성능 이슈를 해결합니다. 좀 더 자세하게 공부해보시면 좋을 것 같아요.(저도 공부를 해오겠습니다.) 
모든 ViewModel을 변경한 것은 아니고 의견을 듣고 점진적으로 변경해보려고 합니다.

바꾼게 많은데 천천히 읽어주시고 모르는 것들을 댓글 달아주시면 도움이 많이 될것같습니다. 감사합니다.


##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->

#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
close #28 


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->