### PR TITLE
[Feat/#29] 워치, 아이폰 간 통신 코드 작성, HealthKit 코드 작성

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -52,6 +52,7 @@ let watchExtensionTarget = Target(
     infoPlist: .file(path: .relativeToRoot("Projects/App/WatchExtension/Resources/InterestWatchExtension-Info.plist")),
     sources: ["WatchExtension/Sources/**"],
     resources: ["WatchExtension/Resources/**"],
+    entitlements: .file(path: .relativeToRoot("Projects/App/WatchExtension/Resources/InterestWatchExtension.entitlements")),
     dependencies: [
         .project(target: "Presentation", path: .relativeToRoot("Projects/Presentation")),
         .project(target: "Data", path: .relativeToRoot("Projects/Data")),

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -18,6 +18,7 @@ let appTarget = Target(
     infoPlist: .file(path: .relativeToRoot("Projects/App/iOS/Resources/InterestApp-Info.plist")),
     sources: ["iOS/Sources/**"],
     resources: ["iOS/Resources/**"],
+    entitlements: .file(path: .relativeToRoot("Projects/App/iOS/Resources/InterestApp.entitlements")),
     dependencies: [
         .target(name: "InterestWatch"),
         .project(target: "Presentation", path: .relativeToRoot("Projects/Presentation")),

--- a/Projects/App/WatchExtension/Resources/InterestWatchExtension-Info.plist
+++ b/Projects/App/WatchExtension/Resources/InterestWatchExtension-Info.plist
@@ -30,6 +30,10 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.watchkit</string>
 	</dict>
+	<key>NSHealthShareUsageDescription</key>
+	<string>건강 데이터 접근 권한이 필요해요.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>건강 데이터 접근 권한이 필요해요.</string>
 	<key>WKExtensionDelegateClassName</key>
 	<string>$(PRODUCT_MODULE_NAME).ExtensionDelegate</string>
 </dict>

--- a/Projects/App/WatchExtension/Resources/InterestWatchExtension.entitlements
+++ b/Projects/App/WatchExtension/Resources/InterestWatchExtension.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+	<key>com.apple.developer.healthkit.access</key>
+	<array/>
+	<key>com.apple.developer.healthkit.background-delivery</key>
+	<true/>
+</dict>
+</plist>

--- a/Projects/App/iOS/Resources/InterestApp-Info.plist
+++ b/Projects/App/iOS/Resources/InterestApp-Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UILaunchStoryboardName</key>
-	<string>Launch</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -22,6 +20,10 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSHealthShareUsageDescription</key>
+	<string>건강 데이터 접근 권한이 필요해요.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>건강 데이터 접근 권한이 필요해요.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -29,6 +31,8 @@
 		<key>UISceneConfigurations</key>
 		<dict/>
 	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>Launch</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/Projects/App/iOS/Resources/InterestApp.entitlements
+++ b/Projects/App/iOS/Resources/InterestApp.entitlements
@@ -4,6 +4,12 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+	<key>com.apple.developer.healthkit.access</key>
+	<array/>
+	<key>com.apple.developer.healthkit.background-delivery</key>
+	<true/>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array/>
 	<key>com.apple.developer.icloud-services</key>

--- a/Projects/Data/Sources/WCSession/DataSource/WCSessionDataSource.swift
+++ b/Projects/Data/Sources/WCSession/DataSource/WCSessionDataSource.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Combine
 
 public protocol WCSessionDataSourceInterface {
 #if os(iOS)

--- a/Projects/Data/Sources/WCSession/DataSource/WCSessionDataSource.swift
+++ b/Projects/Data/Sources/WCSession/DataSource/WCSessionDataSource.swift
@@ -1,0 +1,46 @@
+//
+//  WCSessionDataSource.swift
+//  Data
+//
+//  Created by 김도형 on 1/22/24.
+//
+
+import Foundation
+import Combine
+
+public protocol WCSessionDataSourceInterface {
+#if os(iOS)
+    func checkSessionStatus() -> String
+#endif
+    func sendMessage(_ message: [String: Any])
+    func observeReceiveMessageValue<T>(key: String, valueHandler: @escaping (T) -> Void)
+}
+
+public final class WCSessionDataSource: WCSessionDataSourceInterface {
+    private let manager: WCSessionManager
+    
+    public init(manager: WCSessionManager) {
+        self.manager = manager
+    }
+    
+#if os(iOS)
+    public func checkSessionStatus() -> String {
+        return manager.checkSessionStatus()
+    }
+#endif
+    
+    public func sendMessage(_ message: [String: Any]) {
+        manager.sendMessage(message)
+    }
+    
+    public func observeReceiveMessageValue<T>(key: String, 
+                                       valueHandler: @escaping (T) -> Void) {
+        manager.subcribeReceivedMessage { message in
+            guard let value = message[key] as? T else {
+                return
+            }
+            
+            valueHandler(value)
+        }
+    }
+}

--- a/Projects/Data/Sources/WCSession/Manager/WCSessionManager.swift
+++ b/Projects/Data/Sources/WCSession/Manager/WCSessionManager.swift
@@ -45,17 +45,18 @@ public class WCSessionManager: NSObject, WCSessionDelegate {
             .subscribe(on: DispatchQueue.main)
             .receive(on: DispatchQueue.main)
             .sink { receivedMesssge in
+                print(receivedMesssge)
                 messageHandler(receivedMesssge)
             }
             .store(in: &cancellable)
     }
     
     public func sendMessage(_ message: [String: Any]) {
-        if session.isReachable {
+//        if session.isReachable {
             session.sendMessage(message, replyHandler: nil, errorHandler: { (error) in
                 print("Error sending message: \(error.localizedDescription)")
             })
-        }
+//        }
     }
     
     #if os(iOS)

--- a/Projects/Data/Sources/WCSession/Manager/WCSessionManager.swift
+++ b/Projects/Data/Sources/WCSession/Manager/WCSessionManager.swift
@@ -40,7 +40,7 @@ public class WCSessionManager: NSObject, WCSessionDelegate {
         self.message.send(message)
     }
     
-    public func subcribeReceivedMessage(messageHandler: @escaping ([String: Any]) -> Void) {
+    func subcribeReceivedMessage(messageHandler: @escaping ([String: Any]) -> Void) {
         self.message
             .subscribe(on: DispatchQueue.main)
             .receive(on: DispatchQueue.main)
@@ -51,24 +51,22 @@ public class WCSessionManager: NSObject, WCSessionDelegate {
             .store(in: &cancellable)
     }
     
-    public func sendMessage(_ message: [String: Any]) {
-//        if session.isReachable {
-            session.sendMessage(message, replyHandler: nil, errorHandler: { (error) in
-                print("Error sending message: \(error.localizedDescription)")
-            })
-//        }
+    func sendMessage(_ message: [String: Any]) {
+        session.sendMessage(message, replyHandler: nil, errorHandler: { (error) in
+            print("Error sending message: \(error.localizedDescription)")
+        })
     }
     
     #if os(iOS)
-    public func checkSessionStatus() -> String {
+    func checkSessionStatus() -> WCSessionStatus {
         if !session.isPaired {
-            return "isNotPaired"
+            return .notPaired
         } else if !session.isWatchAppInstalled {
-            return "isNotWatchAppInstalled"
+            return .notInstalledWatchApp
         } else if !session.isReachable {
-            return "isNotReachable"
+            return .notReachable
         } else {
-            return "isConnected"
+            return .connected
         }
     }
     #endif

--- a/Projects/Data/Sources/WCSession/Manager/WCSessionManager.swift
+++ b/Projects/Data/Sources/WCSession/Manager/WCSessionManager.swift
@@ -1,0 +1,74 @@
+//
+//  WCSessionManager.swift
+//  InterestApp
+//
+//  Created by 김도형 on 1/22/24.
+//
+
+import Foundation
+import WatchConnectivity
+import Combine
+
+public class WCSessionManager: NSObject, WCSessionDelegate {
+    private let session = WCSession.default
+    private var message = PassthroughSubject<[String: Any], Never>()
+    private var cancellable = Set<AnyCancellable>()
+    
+    public override init() {
+        super.init()
+        if WCSession.isSupported() {
+            session.delegate = self
+            session.activate()
+        }
+    }
+    
+    public func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        
+    }
+    
+    #if os(iOS)
+    public func sessionDidBecomeInactive(_ session: WCSession) {
+        
+    }
+    
+    public func sessionDidDeactivate(_ session: WCSession) {
+        
+    }
+    #endif
+    
+    public func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {
+        self.message.send(message)
+    }
+    
+    public func subcribeReceivedMessage(messageHandler: @escaping ([String: Any]) -> Void) {
+        self.message
+            .subscribe(on: DispatchQueue.main)
+            .receive(on: DispatchQueue.main)
+            .sink { receivedMesssge in
+                messageHandler(receivedMesssge)
+            }
+            .store(in: &cancellable)
+    }
+    
+    public func sendMessage(_ message: [String: Any]) {
+        if session.isReachable {
+            session.sendMessage(message, replyHandler: nil, errorHandler: { (error) in
+                print("Error sending message: \(error.localizedDescription)")
+            })
+        }
+    }
+    
+    #if os(iOS)
+    public func checkSessionStatus() -> String {
+        if !session.isPaired {
+            return "isNotPaired"
+        } else if !session.isWatchAppInstalled {
+            return "isNotWatchAppInstalled"
+        } else if !session.isReachable {
+            return "isNotReachable"
+        } else {
+            return "isConnected"
+        }
+    }
+    #endif
+}

--- a/Projects/Data/Sources/WCSession/Repository/WCSessionRepository.swift
+++ b/Projects/Data/Sources/WCSession/Repository/WCSessionRepository.swift
@@ -1,0 +1,32 @@
+//
+//  WCSessionRepository.swift
+//  Data
+//
+//  Created by 김도형 on 1/22/24.
+//
+
+import Foundation
+import Combine
+import Domain
+
+public final class WCSessionRepository: WCSessionRepositoryInterface {
+    private let dataSource: WCSessionDataSourceInterface
+    
+    public init(dataSource: WCSessionDataSourceInterface) {
+        self.dataSource = dataSource
+    }
+    
+#if os(iOS)
+    public func checkSessionStatus() -> String {
+        return dataSource.checkSessionStatus()
+    }
+    #endif
+    
+    public func sendMessage(_ message: [String : Any]) {
+        dataSource.sendMessage(message)
+    }
+    
+    public func observeReceiveMessageValue<T>(key: String, valueHandler: @escaping (T) -> Void) {
+        dataSource.observeReceiveMessageValue(key: key, valueHandler: valueHandler)
+    }
+}

--- a/Projects/Data/Sources/WCSession/WCSessionStatus/WCSessionStatus.swift
+++ b/Projects/Data/Sources/WCSession/WCSessionStatus/WCSessionStatus.swift
@@ -1,0 +1,15 @@
+//
+//  WCSessionStatus.swift
+//  Data
+//
+//  Created by 김도형 on 1/24/24.
+//
+
+import Foundation
+
+enum WCSessionStatus: String {
+    case notPaired = "notPaired"
+    case notInstalledWatchApp = "notInstalledWatchApp"
+    case notReachable = "notReachable"
+    case connected = "connect"
+}

--- a/Projects/Data/Sources/Workout/DataSource/WatchOS/WorkoutDataSource+WatchOS.swift
+++ b/Projects/Data/Sources/Workout/DataSource/WatchOS/WorkoutDataSource+WatchOS.swift
@@ -1,0 +1,29 @@
+//
+//  WorkoutDataSource+WatchOS.swift
+//  Data
+//
+//  Created by 김도형 on 1/23/24.
+//
+
+import Foundation
+import HealthKit
+
+#if os(watchOS)
+public extension WorkoutDataSource {
+    func startWorkout(workoutType: HKWorkoutActivityType) {
+        manager.startWorkout(workoutType: workoutType)
+    }
+    
+    func pauseWorkout() {
+        manager.pauseWorkout()
+    }
+    
+    func resumeWorkout() {
+        manager.resumeWorkout()
+    }
+    
+    func endWorkout() {
+        manager.endWorkout()
+    }
+}
+#endif

--- a/Projects/Data/Sources/Workout/DataSource/WorkoutDataSource.swift
+++ b/Projects/Data/Sources/Workout/DataSource/WorkoutDataSource.swift
@@ -1,0 +1,45 @@
+//
+//  WorkoutDataSource.swift
+//  Data
+//
+//  Created by 김도형 on 1/23/24.
+//
+
+import Foundation
+import Combine
+import HealthKit
+
+public protocol WorkoutDataSourceInterface {
+    func requestAuthorization() -> Bool
+    func subcribeHeartRate(updateHandler: @escaping (Double) -> Void)
+    func subcribeCalorie(updateHandler: @escaping (Double) -> Void)
+    
+    #if os(iOS)
+    func fetchHealthKitData(type: HKQuantityTypeIdentifier) async
+    #elseif os(watchOS)
+    func startWorkout(workoutType: HKWorkoutActivityType)
+    func pauseWorkout()
+    func resumeWorkout()
+    func endWorkout()
+    #endif
+}
+
+public final class WorkoutDataSource: WorkoutDataSourceInterface {
+    internal let manager: WorkoutManager
+    
+    public init(manager: WorkoutManager) {
+        self.manager = manager
+    }
+    
+    public func requestAuthorization() -> Bool {
+        return manager.requestAuthorization()
+    }
+    
+    public func subcribeHeartRate(updateHandler: @escaping (Double) -> Void) {
+        manager.subcribeHeartRate(updateHandler: updateHandler)
+    }
+    
+    public func subcribeCalorie(updateHandler: @escaping (Double) -> Void) {
+        manager.subcribeCalorie(updateHandler: updateHandler)
+    }
+}

--- a/Projects/Data/Sources/Workout/DataSource/iOS/WorkoutDataSource+iOS.swift
+++ b/Projects/Data/Sources/Workout/DataSource/iOS/WorkoutDataSource+iOS.swift
@@ -1,0 +1,17 @@
+//
+//  WorkoutDataSource+iOS.swift
+//  Data
+//
+//  Created by 김도형 on 1/23/24.
+//
+
+import Foundation
+import HealthKit
+
+#if os(iOS)
+public extension WorkoutDataSource {
+    func fetchHealthKitData(type: HKQuantityTypeIdentifier) async {
+        await manager.healthKitDataQuery(type: type)
+    }
+}
+#endif

--- a/Projects/Data/Sources/Workout/Manager/WatchOS/WorkoutManager+WatchOS.swift
+++ b/Projects/Data/Sources/Workout/Manager/WatchOS/WorkoutManager+WatchOS.swift
@@ -25,7 +25,7 @@ extension WorkoutManager: HKWorkoutSessionDelegate, HKLiveWorkoutBuilderDelegate
         
     }
     
-    public func startWorkout(workoutType: HKWorkoutActivityType) {
+    func startWorkout(workoutType: HKWorkoutActivityType) {
         let configuration = HKWorkoutConfiguration()
         configuration.activityType = workoutType
         configuration.locationType = .outdoor
@@ -45,15 +45,15 @@ extension WorkoutManager: HKWorkoutSessionDelegate, HKLiveWorkoutBuilderDelegate
         })
     }
     
-    public func pauseWorkout() {
+    func pauseWorkout() {
         session?.pause()
     }
 
-    public func resumeWorkout() {
+    func resumeWorkout() {
         session?.resume()
     }
 
-    public func endWorkout() {
+    func endWorkout() {
         session?.end()
     }
     

--- a/Projects/Data/Sources/Workout/Manager/WatchOS/WorkoutManager+WatchOS.swift
+++ b/Projects/Data/Sources/Workout/Manager/WatchOS/WorkoutManager+WatchOS.swift
@@ -1,0 +1,75 @@
+//
+//  WorkoutManager+WatchOS.swift
+//  Data
+//
+//  Created by 김도형 on 1/23/24.
+//
+
+import Foundation
+import HealthKit
+
+#if os(watchOS)
+extension WorkoutManager: HKWorkoutSessionDelegate, HKLiveWorkoutBuilderDelegate {
+    public func workoutSession(_ workoutSession: HKWorkoutSession, didChangeTo toState: HKWorkoutSessionState, from fromState: HKWorkoutSessionState, date: Date) {
+        
+    }
+    
+    public func workoutSession(_ workoutSession: HKWorkoutSession, didFailWithError error: Error) {
+        
+    }
+    
+    public func startWorkout(workoutType: HKWorkoutActivityType) {
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = workoutType
+        configuration.locationType = .outdoor
+        
+        self.session = try? HKWorkoutSession(healthStore: healthStore, configuration: configuration)
+        builder = session?.associatedWorkoutBuilder()
+        
+        builder?.dataSource = HKLiveWorkoutDataSource(healthStore: healthStore, workoutConfiguration: configuration)
+        
+        session?.delegate = self
+        builder?.delegate = self
+        
+        let startDate = Date()
+        session?.startActivity(with: startDate)
+        builder?.beginCollection(withStart: startDate, completion: { success, error in
+            
+        })
+    }
+    
+    public func pauseWorkout() {
+        session?.pause()
+    }
+
+    public func resumeWorkout() {
+        session?.resume()
+    }
+
+    public func endWorkout() {
+        session?.end()
+    }
+    
+    public func workoutBuilder(_ workoutBuilder: HKLiveWorkoutBuilder, didCollectDataOf collectedTypes: Set<HKSampleType>) {
+        for type in collectedTypes {
+            guard let quantityType = type as? HKQuantityType else {
+                return
+            }
+            
+            guard let statistics = workoutBuilder.statistics(for: quantityType) else {
+                return
+            }
+            
+            guard let quantity = statistics.mostRecentQuantity() else {
+                return
+            }
+            
+            process(quantity, type: quantityType)
+        }
+    }
+    
+    public func workoutBuilderDidCollectEvent(_ workoutBuilder: HKLiveWorkoutBuilder) {
+        
+    }
+}
+#endif

--- a/Projects/Data/Sources/Workout/Manager/WorkoutManager.swift
+++ b/Projects/Data/Sources/Workout/Manager/WorkoutManager.swift
@@ -14,10 +14,17 @@ public class WorkoutManager: NSObject {
     internal var hearRate = PassthroughSubject<Double, Never>()
     internal var calorie = PassthroughSubject<Double, Never>()
     private var cancellable = Set<AnyCancellable>()
-    private var healthKitTypes: Set<HKQuantityType> = [
+    private var healthKitTypes: Set = [
         HKQuantityType(.heartRate),
-        HKQuantityType(.activeEnergyBurned)
+        HKQuantityType(.activeEnergyBurned),
+        HKQuantityType.quantityType(forIdentifier: .distanceWalkingRunning)!,
+        HKObjectType.activitySummaryType()
     ]
+    private var typesToShare: Set = [
+        HKQuantityType.workoutType()
+    ]
+
+    internal var workout: HKWorkout?
     #if os(watchOS)
     internal var session: HKWorkoutSession?
     internal var builder: HKLiveWorkoutBuilder?
@@ -28,23 +35,8 @@ public class WorkoutManager: NSObject {
     public func requestAuthorization() -> Bool {
         var result = false
         
-        healthStore.requestAuthorization(toShare: [], read: healthKitTypes) { success, error in
+        healthStore.requestAuthorization(toShare: typesToShare, read: healthKitTypes) { success, error in
             result = success
-        }
-        
-        if result {
-            let sampleTypes = healthKitTypes.map { type in
-                return type as HKSampleType
-            }
-            for type in sampleTypes {
-                self.healthStore.enableBackgroundDelivery(
-                    for: type,
-                    frequency: .immediate,
-                    withCompletion: { (success, errorOrNil) in
-                        
-                    }
-                )
-            }
         }
         
         return result
@@ -70,14 +62,20 @@ public class WorkoutManager: NSObject {
             .store(in: &cancellable)
     }
     
-    internal func process(_ quantity: HKQuantity,
+    internal func process(_ statistics: HKStatistics?,
                           type: HKQuantityType) {
         switch type {
         case HKQuantityType(.heartRate):
+            guard let quantity = statistics?.mostRecentQuantity() else {
+                break
+            }
             let value = quantity.doubleValue(for: HKUnit(from: "count/min"))
             hearRate.send(value)
             break
         case HKQuantityType(.activeEnergyBurned):
+            guard let quantity = statistics?.sumQuantity() else {
+                break
+            }
             let value = quantity.doubleValue(for: HKUnit.kilocalorie())
             calorie.send(value)
             break

--- a/Projects/Data/Sources/Workout/Manager/WorkoutManager.swift
+++ b/Projects/Data/Sources/Workout/Manager/WorkoutManager.swift
@@ -1,0 +1,88 @@
+//
+//  WorkoutManager.swift
+//  Data
+//
+//  Created by 김도형 on 1/22/24.
+//
+
+import Foundation
+import HealthKit
+import Combine
+
+public class WorkoutManager: NSObject {
+    internal var healthStore = HKHealthStore()
+    internal var hearRate = PassthroughSubject<Double, Never>()
+    internal var calorie = PassthroughSubject<Double, Never>()
+    private var cancellable = Set<AnyCancellable>()
+    private var healthKitTypes: Set<HKQuantityType> = [
+        HKQuantityType(.heartRate),
+        HKQuantityType(.activeEnergyBurned)
+    ]
+    #if os(watchOS)
+    internal var session: HKWorkoutSession?
+    internal var builder: HKLiveWorkoutBuilder?
+    #endif
+    
+    public override init() { }
+    
+    public func requestAuthorization() -> Bool {
+        var result = false
+        
+        healthStore.requestAuthorization(toShare: [], read: healthKitTypes) { success, error in
+            result = success
+        }
+        
+        if result {
+            let sampleTypes = healthKitTypes.map { type in
+                return type as HKSampleType
+            }
+            for type in sampleTypes {
+                self.healthStore.enableBackgroundDelivery(
+                    for: type,
+                    frequency: .immediate,
+                    withCompletion: { (success, errorOrNil) in
+                        
+                    }
+                )
+            }
+        }
+        
+        return result
+    }
+    
+    public func subcribeHeartRate(updateHandler: @escaping (Double) -> Void) {
+        self.hearRate
+            .subscribe(on: DispatchQueue.main)
+            .receive(on: DispatchQueue.main)
+            .sink { value in
+                updateHandler(value)
+            }
+            .store(in: &cancellable)
+    }
+    
+    public func subcribeCalorie(updateHandler: @escaping (Double) -> Void) {
+        self.calorie
+            .subscribe(on: DispatchQueue.main)
+            .receive(on: DispatchQueue.main)
+            .sink { value in
+                updateHandler(value)
+            }
+            .store(in: &cancellable)
+    }
+    
+    internal func process(_ quantity: HKQuantity,
+                          type: HKQuantityType) {
+        switch type {
+        case HKQuantityType(.heartRate):
+            let value = quantity.doubleValue(for: HKUnit(from: "count/min"))
+            hearRate.send(value)
+            break
+        case HKQuantityType(.activeEnergyBurned):
+            let value = quantity.doubleValue(for: HKUnit.kilocalorie())
+            calorie.send(value)
+            break
+        default:
+            break
+        }
+    }
+}

--- a/Projects/Data/Sources/Workout/Manager/WorkoutManager.swift
+++ b/Projects/Data/Sources/Workout/Manager/WorkoutManager.swift
@@ -32,7 +32,7 @@ public class WorkoutManager: NSObject {
     
     public override init() { }
     
-    public func requestAuthorization() -> Bool {
+    func requestAuthorization() -> Bool {
         var result = false
         
         healthStore.requestAuthorization(toShare: typesToShare, read: healthKitTypes) { success, error in
@@ -42,7 +42,7 @@ public class WorkoutManager: NSObject {
         return result
     }
     
-    public func subcribeHeartRate(updateHandler: @escaping (Double) -> Void) {
+    func subcribeHeartRate(updateHandler: @escaping (Double) -> Void) {
         self.hearRate
             .subscribe(on: DispatchQueue.main)
             .receive(on: DispatchQueue.main)
@@ -52,7 +52,7 @@ public class WorkoutManager: NSObject {
             .store(in: &cancellable)
     }
     
-    public func subcribeCalorie(updateHandler: @escaping (Double) -> Void) {
+    func subcribeCalorie(updateHandler: @escaping (Double) -> Void) {
         self.calorie
             .subscribe(on: DispatchQueue.main)
             .receive(on: DispatchQueue.main)

--- a/Projects/Data/Sources/Workout/Manager/iOS/WorkoutManager+iOS.swift
+++ b/Projects/Data/Sources/Workout/Manager/iOS/WorkoutManager+iOS.swift
@@ -14,15 +14,14 @@ public extension WorkoutManager {
         let completionHandler: (HKStatisticsQuery,
                             HKStatistics?,
                             Error?) -> Void = { query, statistics, error in
-            guard let quantity = statistics?.mostRecentQuantity() else {
-                return
-            }
             
-            self.process(quantity, type: HKQuantityType(type))
+            self.process(statistics, type: HKQuantityType(type))
         }
         
+        let devicePredicate = HKQuery.predicateForObjects(from: [HKDevice.local()])
+        
         let query = HKStatisticsQuery(quantityType: HKQuantityType(type),
-                                      quantitySamplePredicate: nil,
+                                      quantitySamplePredicate: devicePredicate,
                                       options: .mostRecent,
                                       completionHandler: completionHandler)
         

--- a/Projects/Data/Sources/Workout/Manager/iOS/WorkoutManager+iOS.swift
+++ b/Projects/Data/Sources/Workout/Manager/iOS/WorkoutManager+iOS.swift
@@ -1,0 +1,32 @@
+//
+//  WorkoutManager+iOS.swift
+//  Data
+//
+//  Created by 김도형 on 1/23/24.
+//
+
+import Foundation
+import HealthKit
+
+#if os(iOS)
+public extension WorkoutManager {
+    func healthKitDataQuery(type: HKQuantityTypeIdentifier) async {
+        let completionHandler: (HKStatisticsQuery,
+                            HKStatistics?,
+                            Error?) -> Void = { query, statistics, error in
+            guard let quantity = statistics?.mostRecentQuantity() else {
+                return
+            }
+            
+            self.process(quantity, type: HKQuantityType(type))
+        }
+        
+        let query = HKStatisticsQuery(quantityType: HKQuantityType(type),
+                                      quantitySamplePredicate: nil,
+                                      options: .mostRecent,
+                                      completionHandler: completionHandler)
+        
+        healthStore.execute(query)
+    }
+}
+#endif

--- a/Projects/Data/Sources/Workout/Manager/iOS/WorkoutManager+iOS.swift
+++ b/Projects/Data/Sources/Workout/Manager/iOS/WorkoutManager+iOS.swift
@@ -9,19 +9,16 @@ import Foundation
 import HealthKit
 
 #if os(iOS)
-public extension WorkoutManager {
+extension WorkoutManager {
     func healthKitDataQuery(type: HKQuantityTypeIdentifier) async {
         let completionHandler: (HKStatisticsQuery,
-                            HKStatistics?,
-                            Error?) -> Void = { query, statistics, error in
-            
+                                HKStatistics?,
+                                Error?) -> Void = { query, statistics, error in
             self.process(statistics, type: HKQuantityType(type))
         }
         
-        let devicePredicate = HKQuery.predicateForObjects(from: [HKDevice.local()])
-        
         let query = HKStatisticsQuery(quantityType: HKQuantityType(type),
-                                      quantitySamplePredicate: devicePredicate,
+                                      quantitySamplePredicate: nil,
                                       options: .mostRecent,
                                       completionHandler: completionHandler)
         

--- a/Projects/Data/Sources/Workout/Repository/WatchOS/WorkoutRepository+WatchOS.swift
+++ b/Projects/Data/Sources/Workout/Repository/WatchOS/WorkoutRepository+WatchOS.swift
@@ -1,0 +1,29 @@
+//
+//  WorkoutRepository+WatchOS.swift
+//  Data
+//
+//  Created by 김도형 on 1/23/24.
+//
+
+import Foundation
+import HealthKit
+
+#if os(watchOS)
+public extension WorkoutRepository {
+    func startWorkout(workoutType: HKWorkoutActivityType) {
+        dataSource.startWorkout(workoutType: workoutType)
+    }
+    
+    func pauseWorkout() {
+        dataSource.pauseWorkout()
+    }
+    
+    func resumeWorkout() {
+        dataSource.resumeWorkout()
+    }
+    
+    func endWorkout() {
+        dataSource.endWorkout()
+    }
+}
+#endif

--- a/Projects/Data/Sources/Workout/Repository/WorkoutRepository.swift
+++ b/Projects/Data/Sources/Workout/Repository/WorkoutRepository.swift
@@ -8,7 +8,9 @@
 import Foundation
 import HealthKit
 
-public final class WorkoutRepository: WorkoutDataSourceInterface {
+import Domain
+
+public final class WorkoutRepository: WorkoutRepositoryInterface {
     internal let dataSource: WorkoutDataSource
     
     public init(dataSource: WorkoutDataSource) {

--- a/Projects/Data/Sources/Workout/Repository/WorkoutRepository.swift
+++ b/Projects/Data/Sources/Workout/Repository/WorkoutRepository.swift
@@ -1,0 +1,29 @@
+//
+//  WorkoutRepository.swift
+//  Data
+//
+//  Created by 김도형 on 1/23/24.
+//
+
+import Foundation
+import HealthKit
+
+public final class WorkoutRepository: WorkoutDataSourceInterface {
+    internal let dataSource: WorkoutDataSource
+    
+    public init(dataSource: WorkoutDataSource) {
+        self.dataSource = dataSource
+    }
+    
+    public func requestAuthorization() -> Bool {
+        return dataSource.requestAuthorization()
+    }
+    
+    public func subcribeHeartRate(updateHandler: @escaping (Double) -> Void) {
+        dataSource.subcribeHeartRate(updateHandler: updateHandler)
+    }
+    
+    public func subcribeCalorie(updateHandler: @escaping (Double) -> Void) {
+        dataSource.subcribeCalorie(updateHandler: updateHandler)
+    }
+}

--- a/Projects/Data/Sources/Workout/Repository/iOS/WorkoutRepository+iOS.swift
+++ b/Projects/Data/Sources/Workout/Repository/iOS/WorkoutRepository+iOS.swift
@@ -1,0 +1,17 @@
+//
+//  WorkoutRepository+iOS.swift
+//  Data
+//
+//  Created by 김도형 on 1/23/24.
+//
+
+import Foundation
+import HealthKit
+
+#if os(iOS)
+public extension WorkoutRepository {
+    func fetchHealthKitData(type: HKQuantityTypeIdentifier) async {
+        await dataSource.fetchHealthKitData(type: type)
+    }
+}
+#endif

--- a/Projects/Domain/Sources/WCSession/Respository/WCSessionRepositoryInterface.swift
+++ b/Projects/Domain/Sources/WCSession/Respository/WCSessionRepositoryInterface.swift
@@ -1,0 +1,17 @@
+//
+//  WCSessionRepositoryInterface.swift
+//  Domain
+//
+//  Created by 김도형 on 1/22/24.
+//
+
+import Foundation
+import Combine
+
+public protocol WCSessionRepositoryInterface {
+#if os(iOS)
+    func checkSessionStatus() -> String
+#endif
+    func sendMessage(_ message: [String: Any])
+    func observeReceiveMessageValue<T>(key: String, valueHandler: @escaping (T) -> Void)
+}

--- a/Projects/Domain/Sources/WCSession/UseCase/WCSessionUseCase.swift
+++ b/Projects/Domain/Sources/WCSession/UseCase/WCSessionUseCase.swift
@@ -1,0 +1,39 @@
+//
+//  WCSessionUseCase.swift
+//  Domain
+//
+//  Created by 김도형 on 1/22/24.
+//
+
+import Foundation
+import Combine
+
+public protocol WCSessionUseCaseInterface {
+#if os(iOS)
+    func checkSessionStatus() -> String
+#endif
+    func sendMessage(_ message: [String: Any])
+    func observeReceiveMessageValue<T>(key: String, valueHandler: @escaping (T) -> Void)
+}
+
+public final class WCSessionUseCase: WCSessionUseCaseInterface {
+    private let repository: WCSessionRepositoryInterface
+    
+    public init(repository: WCSessionRepositoryInterface) {
+        self.repository = repository
+    }
+    
+#if os(iOS)
+    public func checkSessionStatus() -> String {
+        return repository.checkSessionStatus()
+    }
+#endif
+    
+    public func sendMessage(_ message: [String : Any]) {
+        repository.sendMessage(message)
+    }
+    
+    public func observeReceiveMessageValue<T>(key: String, valueHandler: @escaping (T) -> Void) {
+        repository.observeReceiveMessageValue(key: key, valueHandler: valueHandler)
+    }
+}

--- a/Projects/Domain/Sources/Workout/Repository/WorkoutRepositoryInterface.swift
+++ b/Projects/Domain/Sources/Workout/Repository/WorkoutRepositoryInterface.swift
@@ -1,0 +1,24 @@
+//
+//  WorkoutRepositoryInterface.swift
+//  Domain
+//
+//  Created by 김도형 on 1/23/24.
+//
+
+import Foundation
+import HealthKit
+
+public protocol WorkoutRepositoryInterface {
+    func requestAuthorization() -> Bool
+    func subcribeHeartRate(updateHandler: @escaping (Double) -> Void)
+    func subcribeCalorie(updateHandler: @escaping (Double) -> Void)
+    
+    #if os(iOS)
+    func fetchHealthKitData(type: HKQuantityTypeIdentifier) async
+    #elseif os(watchOS)
+    func startWorkout(workoutType: HKWorkoutActivityType)
+    func pauseWorkout()
+    func resumeWorkout()
+    func endWorkout()
+    #endif
+}

--- a/Projects/Domain/Sources/Workout/UseCase/WatchOS/WorkoutUseCase+WatchOS.swift
+++ b/Projects/Domain/Sources/Workout/UseCase/WatchOS/WorkoutUseCase+WatchOS.swift
@@ -1,0 +1,29 @@
+//
+//  WorkoutUseCase+WatchOS.swift
+//  Domain
+//
+//  Created by 김도형 on 1/23/24.
+//
+
+import Foundation
+import HealthKit
+
+#if os(watchOS)
+public extension WorkoutUseCase {
+    func startWorkout(workoutType: HKWorkoutActivityType) {
+        repository.startWorkout(workoutType: workoutType)
+    }
+    
+    func pauseWorkout() {
+        repository.pauseWorkout()
+    }
+    
+    func resumeWorkout() {
+        repository.resumeWorkout()
+    }
+    
+    func endWorkout() {
+        repository.endWorkout()
+    }
+}
+#endif

--- a/Projects/Domain/Sources/Workout/UseCase/WorkoutUseCase.swift
+++ b/Projects/Domain/Sources/Workout/UseCase/WorkoutUseCase.swift
@@ -1,0 +1,44 @@
+//
+//  WorkoutUseCase.swift
+//  Domain
+//
+//  Created by 김도형 on 1/23/24.
+//
+
+import Foundation
+import HealthKit
+
+public protocol WorkoutUseCaseInterface {
+    func requestAuthorization() -> Bool
+    func subcribeHeartRate(updateHandler: @escaping (Double) -> Void)
+    func subcribeCalorie(updateHandler: @escaping (Double) -> Void)
+    
+    #if os(iOS)
+    func fetchHealthKitData(type: HKQuantityTypeIdentifier) async
+    #elseif os(watchOS)
+    func startWorkout(workoutType: HKWorkoutActivityType)
+    func pauseWorkout()
+    func resumeWorkout()
+    func endWorkout()
+    #endif
+}
+
+public final class WorkoutUseCase: WorkoutUseCaseInterface {
+    internal let repository: WorkoutRepositoryInterface
+    
+    public init(repository: WorkoutRepositoryInterface) {
+        self.repository = repository
+    }
+    
+    public func requestAuthorization() -> Bool {
+        return repository.requestAuthorization()
+    }
+    
+    public func subcribeHeartRate(updateHandler: @escaping (Double) -> Void) {
+        repository.subcribeHeartRate(updateHandler: updateHandler)
+    }
+    
+    public func subcribeCalorie(updateHandler: @escaping (Double) -> Void) {
+        repository.subcribeCalorie(updateHandler: updateHandler)
+    }
+}

--- a/Projects/Domain/Sources/Workout/UseCase/iOS/WorkoutUseCase+iOS.swift
+++ b/Projects/Domain/Sources/Workout/UseCase/iOS/WorkoutUseCase+iOS.swift
@@ -1,0 +1,17 @@
+//
+//  WorkoutUseCase+iOS.swift
+//  Domain
+//
+//  Created by 김도형 on 1/23/24.
+//
+
+import Foundation
+import HealthKit
+
+#if os(iOS)
+public extension WorkoutUseCase {
+    func fetchHealthKitData(type: HKQuantityTypeIdentifier) async {
+        await repository.fetchHealthKitData(type: type)
+    }
+}
+#endif


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
1. 워치 아이폰간 연동을 위해 WCSession 사용을 위해 Data 계층에 WCSessionManager라는 WCSession 대리자를 작성하였습니다.
2. Combine을 조금 섞어서, WCSessionManager 안에 message Subject를 선언하여 message가 값을 방출할때가 관찰 트리거가 되도록 하였습니다.
3. WCSession 관련 비지니스 로직은 연동상태 확인(ios만 가능), 메세지 보내기, 메세지 관찰 총 3가지로 작성하였습니다.
4. 심박수와 칼로리를 가져오기 위해 Data 계층에 WorkoutManager를 작성하였습니다.
5. WorkoutManager역시 Combine을 사용하였습니다.
6. Workout 비지니스 로직은, 건강 데이터 접근 권한 확인, 심박수 관찰, 칼로리 관찰, 건강데이터 조회(ios), workout 핸들링(watchOS)로 작성하였습니다.
#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->

##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->
1. Combine을 네트워크 통신 외에 데이터 흐름 제어로 써보는거는 처음이라 잘못된 부분이 있으면 알려주세요!(사실 이런거에 combine 써보고 싶었음)
2. Delegate들을 Data 영역에 둬야할지, EnvironmentObject로 관리해야할지 고민을 좀 했어요. 의견이 어떤지 궁급합니다!(일단 전자로 구현)
3. 제가 HealthKit이 처음이라 잘 몰라서 그런거일 수 도 있는데, 아이폰으로 받아오는 심박수나 칼로리가 10분전(?) 5분전(?) 이런 값들이라 원래 아이폰으로 데이터를 받아오는게 아닌건지 궁금합니다!
4. 2번 문제 때문에 workout을 사용하여 워치로 심박수와 칼로리를 받아오고 아이폰으로 보내주려고 했는데, WatchExtesion에 HealthKit Capablity를 추가 하면 signing 오류가 나서 코드만 작성하고 테스트는 못했습니다.
<img width="438" alt="스크린샷 2024-01-23 18 58 44" src="https://github.com/TEAM-ALOM/interest-iOS/assets/108233361/61ac8561-4f79-4b7f-abba-929d753e6d71">

5. 테스트용 코드는 커밋에 포함시키지 않았습니다.(충돌이 많이 일어날 것 같음)
6. 워치, 아이폰간 통신으로 화면 넘어가게 하는건 잘 되는데, 워치에서 어플이 꺼져 있거나, 아이폰에서 어플이 꺼져있을 경우는 어떻게 해야할지 모르겠어요..
7. 연동 테스트는 화면으로 보여주고 싶은데, 시뮬레이터 페어링이 잘 안되서 포기...

+ 이제 드디어 Workout 기능을 디버깅 할 수 있어서 코드 개선을 진행했습니다.
워치가 측정한 운동 데이터를 아이폰으로 전송하는 로직을 염두해 두고 개선하였습니다.

https://github.com/TEAM-ALOM/interest-iOS/assets/108233361/f8478160-4a0e-429f-a97f-4e96d732466c

#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
25
close #


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->